### PR TITLE
Use built-in deep equal library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var deepEql = require('deep-eql');
-
 var DEFAULT_TOLERANCE = 1e-6;
 
 module.exports = function (chai, utils) {
@@ -11,7 +9,7 @@ module.exports = function (chai, utils) {
       if (tolerance) {
         if (msg) flag(this, 'message', msg);
         this.assert(
-          deepEql(obj, utils.flag(this, 'object'), { tolerance: tolerance })
+          utils.eql(obj, utils.flag(this, 'object'), { tolerance: tolerance })
           , 'expected #{this} to roughly deeply equal #{exp}'
           , 'expected #{this} to not roughly deeply equal #{exp}'
           , obj

--- a/package.json
+++ b/package.json
@@ -29,7 +29,5 @@
     "chai": "^3.5.0",
     "mocha": "^2.4.5"
   },
-  "dependencies": {
-    "deep-eql": "git+https://github.com/Turbo87/deep-eql.git#9bad4db"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
There is copy of  `deep-eql` library in the chai utils, so we can drop that dependency.
