### PR TITLE
Extend roughly to allow a comparator function to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ chai.use(require('chai-roughly'));
 ```
 
 Now you can use the `expect(...).to.roughly.deep.equal(...)` chain for deep
-equals assertions with tolerance for numbers. The default tolerance is `1e-6`
-and can be overwritten by using e.g.
-`expect(...).to.roughly(0.001).deep.equal(...)`.
+equals assertions with tolerance for numbers. 
 
 ```js
 it('works', function() {
@@ -39,6 +37,35 @@ it('works', function() {
 });
 ```
 
+The default tolerance is `1e-6` and can be overwritten.  For example:
+
+```js
+it('works', function() {
+  expect({ value: 42 }).to.roughly(0.001).deep.equal({ value: 41.9999999 });
+});
+```
+
+The tolerance is a relative tolerance.
+
+In addition a comparator function can be specified corresponding to the comparator which 
+`deep-eql` accepts.  
+
+```js
+
+var comparator = roughly.createAbsoluteComparator(0.01);
+
+it('works', function() {
+  expect({ value: 42 }).to.roughly(comparator).deep.equal({ value: 41.9999999 });
+});
+```
+
+There are several helper functions to create comparator functions which are exported in the roughly module:
+
+```js
+function createAbsoluteComparator(absoluteTolerance)
+function createRelativeComparator(relativeTolerance)
+function createAbsoluteOrRelativeComparator(absoluteTolerance, relativeTolerance)
+```
 
 License
 ------------------------------------------------------------------------------

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var deepEql = require('deep-eql');
+var type = require('type-detect');
 
 var DEFAULT_TOLERANCE = 1e-6;
 
@@ -6,12 +7,12 @@ module.exports = function (chai, utils) {
   var Assertion = chai.Assertion;
 
   function assertEql(_super) {
-    return function(obj, msg) {
-      var tolerance = utils.flag(this, 'tolerance');
-      if (tolerance) {
+    return function (obj, msg) {
+      var comparator = utils.flag(this, 'comparator');
+      if (comparator) {
         if (msg) flag(this, 'message', msg);
         this.assert(
-          deepEql(obj, utils.flag(this, 'object'), { tolerance: tolerance })
+          deepEql(obj, utils.flag(this, 'object'), { comparator: comparator })
           , 'expected #{this} to roughly deeply equal #{exp}'
           , 'expected #{this} to not roughly deeply equal #{exp}'
           , obj
@@ -28,13 +29,91 @@ module.exports = function (chai, utils) {
   Assertion.overwriteMethod('eql', assertEql);
   Assertion.overwriteMethod('eqls', assertEql);
 
-  function explicitRoughly(tolerance) {
-    utils.flag(this, 'tolerance', tolerance);
+  function checkComparator(comparatorOrTolerance) {
+    if ('number' === type(comparatorOrTolerance)) {
+      return createRelativeComparator(comparatorOrTolerance);
+    } else if ('function' === type(comparatorOrTolerance)) {
+      return comparatorOrTolerance;
+    } else {
+      throw new Error('Roughly must be given a relative tolerance number or comparator function');
+    }
+  }
+
+  function explicitRoughly(comparatorOrTolerance) {
+    utils.flag(this, 'comparator', checkComparator(comparatorOrTolerance));
   }
 
   function defaultRoughly() {
-    utils.flag(this, 'tolerance', DEFAULT_TOLERANCE);
+    utils.flag(this, 'comparator', createRelativeComparator(DEFAULT_TOLERANCE));
   }
 
   Assertion.addChainableMethod('roughly', explicitRoughly, defaultRoughly);
 };
+
+// copied from deep-eql
+function simpleEqual(a, b) {
+  // Equal references (except for Numbers) can be returned early
+  if (a === b) {
+    // Handle +-0 cases
+    return a !== 0 || 1 / a === 1 / b;
+  }
+
+  // handle NaN cases
+  return (
+    a !== a && // eslint-disable-line no-self-compare
+    b !== b // eslint-disable-line no-self-compare
+  );
+}
+
+// numberCompare is a function which takes two numbers as input
+// and returns a boolean indicating whether they match or not.
+// createComparator returns a function which takes two values (of any type)
+// and returns null if either is not a number, otherwise a boolean
+// indicating whether they match or not.
+
+function createComparator(numberCompare) {
+
+  return function (a, b) {
+    if (simpleEqual(a, b)) {
+      return true;
+    } else if ('number' !== type(a) || 'number' !== type(b)) {
+      return null;
+    }
+
+    return numberCompare(a, b);
+  }
+}
+
+function absoluteTest(a, b, absoluteTolerance) {
+    return Math.abs(a - b) < absoluteTolerance;
+}
+
+function relativeTest(a, b, relativeTolerance) {
+    var base = Math.max(Math.abs(a), Math.abs(b));
+    var acceptableDiff = relativeTolerance * base;
+    return Math.abs(b - a) <= Math.abs(acceptableDiff);
+}
+
+function createAbsoluteComparator(absoluteTolerance) {
+  return createComparator(function (a, b) {
+    return absoluteTest(a, b, absoluteTolerance);
+  });
+}
+
+function createRelativeComparator(relativeTolerance) {
+  return createComparator(function (a, b) {
+    return relativeTest(a, b, relativeTolerance);
+  });
+}
+
+function createAbsoluteOrRelativeComparator(absoluteTolerance, relativeTolerance) {
+  return createComparator(function (a, b) {
+    return absoluteTest(a, b, absoluteTolerance) || relativeTest(a, b, relativeTolerance);
+  });
+
+}
+
+module.exports.createComparator = createComparator;
+module.exports.createAbsoluteComparator = createAbsoluteComparator;
+module.exports.createRelativeComparator = createRelativeComparator;
+module.exports.createAbsoluteOrRelativeComparator = createAbsoluteOrRelativeComparator;

--- a/index.js
+++ b/index.js
@@ -3,11 +3,11 @@ var type = require('type-detect');
 
 var DEFAULT_TOLERANCE = 1e-6;
 
-module.exports = function (chai, utils) {
+module.exports = function(chai, utils) {
   var Assertion = chai.Assertion;
 
   function assertEql(_super) {
-    return function (obj, msg) {
+    return function(obj, msg) {
       var comparator = utils.flag(this, 'comparator');
       if (comparator) {
         if (msg) flag(this, 'message', msg);
@@ -73,7 +73,7 @@ function simpleEqual(a, b) {
 
 function createComparator(numberCompare) {
 
-  return function (a, b) {
+  return function(a, b) {
     if (simpleEqual(a, b)) {
       return true;
     } else if ('number' !== type(a) || 'number' !== type(b)) {
@@ -95,19 +95,19 @@ function relativeTest(a, b, relativeTolerance) {
 }
 
 function createAbsoluteComparator(absoluteTolerance) {
-  return createComparator(function (a, b) {
+  return createComparator(function(a, b) {
     return absoluteTest(a, b, absoluteTolerance);
   });
 }
 
 function createRelativeComparator(relativeTolerance) {
-  return createComparator(function (a, b) {
+  return createComparator(function(a, b) {
     return relativeTest(a, b, relativeTolerance);
   });
 }
 
 function createAbsoluteOrRelativeComparator(absoluteTolerance, relativeTolerance) {
-  return createComparator(function (a, b) {
+  return createComparator(function(a, b) {
     return absoluteTest(a, b, absoluteTolerance) || relativeTest(a, b, relativeTolerance);
   });
 

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
   },
   "homepage": "https://github.com/Turbo87/chai-roughly#readme",
   "devDependencies": {
-    "chai": "^3.5.0",
-    "mocha": "^3.0.0"
+    "chai": "^4.0.2",
+    "mocha": "^3.2.0"
   },
   "dependencies": {
-    "deep-eql": "git+https://github.com/Turbo87/deep-eql.git#9bad4db"
+    "deep-eql": "^2.0.2",
+    "type-detect": "^3.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -9,22 +9,22 @@ var expect = chai.expect;
 var roughly = require('./index');
 chai.use(roughly);
 
-describe('expect(...).to.roughly.deep.equal(...)', function () {
-  it('passes for empty objects', function () {
+describe('expect(...).to.roughly.deep.equal(...)', function() {
+  it('passes for empty objects', function() {
     expect({}).to.roughly.deep.equal({});
   });
 
-  it('passes for roughly similar values', function () {
+  it('passes for roughly similar values', function() {
     expect({ value: 12345 }).to.roughly.deep.equal({ value: 12345.01 });
   });
 
-  it('fails for different values', function () {
-    expect(function () {
+  it('fails for different values', function() {
+    expect(function() {
       expect({ value: 12345 }).to.roughly.deep.equal({ value: 12345.1 });
     }).to.throw();
   });
 
-  it('passes for multiple roughly similar values', function () {
+  it('passes for multiple roughly similar values', function() {
     expect({
       value: 12345,
       other: 0.1234,
@@ -34,7 +34,7 @@ describe('expect(...).to.roughly.deep.equal(...)', function () {
     });
   });
 
-  it('passes for roughly similar nested values', function () {
+  it('passes for roughly similar nested values', function() {
     expect({
       sub: {
         value: 42,
@@ -47,22 +47,22 @@ describe('expect(...).to.roughly.deep.equal(...)', function () {
   });
 });
 
-describe('expect(...).to.roughly(tolerance).deep.equal(...)', function () {
-  it('passes for empty objects', function () {
+describe('expect(...).to.roughly(tolerance).deep.equal(...)', function() {
+  it('passes for empty objects', function() {
     expect({}).to.roughly(1e-4).deep.equal({});
   });
 
-  it('passes for roughly similar values', function () {
+  it('passes for roughly similar values', function() {
     expect({ value: 12345 }).to.roughly(1e-4).deep.equal({ value: 12345.1 });
   });
 
-  it('fails for different values', function () {
-    expect(function () {
+  it('fails for different values', function() {
+    expect(function() {
       expect({ value: 12345 }).to.roughly(1e-4).deep.equal({ value: 12341 });
     }).to.throw();
   });
 
-  it('passes for multiple roughly similar values', function () {
+  it('passes for multiple roughly similar values', function() {
     expect({
       value: 12345,
       other: 0.1234,
@@ -72,7 +72,7 @@ describe('expect(...).to.roughly(tolerance).deep.equal(...)', function () {
     });
   });
 
-  it('passes for roughly similar nested values', function () {
+  it('passes for roughly similar nested values', function() {
     expect({
       sub: {
         value: 42,
@@ -85,25 +85,25 @@ describe('expect(...).to.roughly(tolerance).deep.equal(...)', function () {
   });
 });
 
-describe('expect(...).to.roughly(comparator).deep.equal(...)', function () {
+describe('expect(...).to.roughly(comparator).deep.equal(...)', function() {
 
   var comparator = roughly.createAbsoluteComparator(0.01);
 
-  it('passes for empty objects', function () {
+  it('passes for empty objects', function() {
     expect({}).to.roughly(comparator).deep.equal({});
   });
 
-  it('passes for roughly similar values', function () {
+  it('passes for roughly similar values', function() {
     expect({ value: 12345 }).to.roughly(comparator).deep.equal({ value: 12345.009 });
   });
 
-  it('fails for different values', function () {
-    expect(function () {
+  it('fails for different values', function() {
+    expect(function() {
       expect({ value: 12345 }).to.roughly(comparator).deep.equal({ value: 12345.02 });
     }).to.throw();
   });
 
-  it('passes for multiple roughly similar values', function () {
+  it('passes for multiple roughly similar values', function() {
     expect({
       value: 12345,
       other: 12.129,
@@ -113,7 +113,7 @@ describe('expect(...).to.roughly(comparator).deep.equal(...)', function () {
     });
   });
 
-  it('passes for roughly similar nested values', function () {
+  it('passes for roughly similar nested values', function() {
     expect({
       sub: {
         value: 42,

--- a/test.js
+++ b/test.js
@@ -1,28 +1,30 @@
 var mocha = require('mocha');
 var chai = require('chai');
+var type = require('type-detect');
 
 var describe = mocha.describe;
 var it = mocha.it;
 var expect = chai.expect;
 
-chai.use(require('./index'));
+var roughly = require('./index');
+chai.use(roughly);
 
-describe('expect(...).to.roughly.deep.equal(...)', function() {
-  it('passes for empty objects', function() {
+describe('expect(...).to.roughly.deep.equal(...)', function () {
+  it('passes for empty objects', function () {
     expect({}).to.roughly.deep.equal({});
   });
 
-  it('passes for roughly similar values', function() {
+  it('passes for roughly similar values', function () {
     expect({ value: 12345 }).to.roughly.deep.equal({ value: 12345.01 });
   });
 
-  it('fails for different values', function() {
-    expect(function() {
+  it('fails for different values', function () {
+    expect(function () {
       expect({ value: 12345 }).to.roughly.deep.equal({ value: 12345.1 });
     }).to.throw();
   });
 
-  it('passes for multiple roughly similar values', function() {
+  it('passes for multiple roughly similar values', function () {
     expect({
       value: 12345,
       other: 0.1234,
@@ -32,7 +34,7 @@ describe('expect(...).to.roughly.deep.equal(...)', function() {
     });
   });
 
-  it('passes for roughly similar nested values', function() {
+  it('passes for roughly similar nested values', function () {
     expect({
       sub: {
         value: 42,
@@ -40,6 +42,85 @@ describe('expect(...).to.roughly.deep.equal(...)', function() {
     }).to.roughly.deep.equal({
       sub: {
         value: 41.99999,
+      },
+    });
+  });
+});
+
+describe('expect(...).to.roughly(tolerance).deep.equal(...)', function () {
+  it('passes for empty objects', function () {
+    expect({}).to.roughly(1e-4).deep.equal({});
+  });
+
+  it('passes for roughly similar values', function () {
+    expect({ value: 12345 }).to.roughly(1e-4).deep.equal({ value: 12345.1 });
+  });
+
+  it('fails for different values', function () {
+    expect(function () {
+      expect({ value: 12345 }).to.roughly(1e-4).deep.equal({ value: 12341 });
+    }).to.throw();
+  });
+
+  it('passes for multiple roughly similar values', function () {
+    expect({
+      value: 12345,
+      other: 0.1234,
+    }).to.roughly(1e-4).deep.equal({
+      other: 0.12341,
+      value: 12345.1,
+    });
+  });
+
+  it('passes for roughly similar nested values', function () {
+    expect({
+      sub: {
+        value: 42,
+      },
+    }).to.roughly(1e-4).deep.equal({
+      sub: {
+        value: 41.999,
+      },
+    });
+  });
+});
+
+describe('expect(...).to.roughly(comparator).deep.equal(...)', function () {
+
+  var comparator = roughly.createAbsoluteComparator(0.01);
+
+  it('passes for empty objects', function () {
+    expect({}).to.roughly(comparator).deep.equal({});
+  });
+
+  it('passes for roughly similar values', function () {
+    expect({ value: 12345 }).to.roughly(comparator).deep.equal({ value: 12345.009 });
+  });
+
+  it('fails for different values', function () {
+    expect(function () {
+      expect({ value: 12345 }).to.roughly(comparator).deep.equal({ value: 12345.02 });
+    }).to.throw();
+  });
+
+  it('passes for multiple roughly similar values', function () {
+    expect({
+      value: 12345,
+      other: 12.129,
+    }).to.roughly(comparator).deep.equal({
+      other: 12.123,
+      value: 12345.002,
+    });
+  });
+
+  it('passes for roughly similar nested values', function () {
+    expect({
+      sub: {
+        value: 42,
+      },
+    }).to.roughly(comparator).deep.equal({
+      sub: {
+        value: 41.995,
       },
     });
   });


### PR DESCRIPTION
This extension allows custom comparison functions: for example using a combination of relative and absolute tolerances.

`deep-eql` now allows a comparator function to be specified: https://github.com/chaijs/deep-eql/blob/master/index.js#L169

This pull-request updates chai-roughly as follows:
a) upgrades to latest deep-eql
b) allows roughly(f) where f is a comparator function like used in deep-eql.  
c) still supports roughly(t) where t is a number and specifies a relative tolerance, so is back-compatible.
